### PR TITLE
Fixing loggerOptions bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ var winston = require('winston');
 var logzioWinstonTransport = require('winston-logzio');
 
 var loggerOptions = {
-    apiToken: '__YOUR_API_TOKEN__'
+    token: '__YOUR_API_TOKEN__'
 };
 winston.add(logzioWinstonTransport, loggerOptions);
 


### PR DESCRIPTION
Option should be *token* and not *apiToken*, otherwise getting the following error:
```
throw new Error('You are required to supply a token for logging.');
```