### PR TITLE
Upgrade snyk and move to dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "json-stringify-safe": "5.0.1",
         "lodash.assign": "4.2.0",
         "logzio-nodejs": "^2.1.4",
-        "snyk": "^1.685.0",
         "triple-beam": "^1.3.0",
         "winston": "^3.8.2",
         "winston-transport": "^4.5.0"
@@ -24,7 +23,8 @@
         "eslint-config-airbnb-base": "^13.1.0",
         "eslint-plugin-import": "^2.14.0",
         "mocha": "^5.2.0",
-        "sinon": "^1.17.1"
+        "sinon": "^1.17.1",
+        "snyk": "^1.1190.0"
       },
       "engines": {
         "node": ">= 8.4.0"

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "logzio-nodejs": "^2.1.4",
     "triple-beam": "^1.3.0",
     "winston": "^3.8.2",
-    "winston-transport": "^4.5.0",
-    "snyk": "^1.685.0"
+    "winston-transport": "^4.5.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",
@@ -58,7 +57,8 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "mocha": "^5.2.0",
-    "sinon": "^1.17.1"
+    "sinon": "^1.17.1",
+    "snyk": "^1.1190.0"
   },
   "main": "./lib/winston-logzio",
   "engines": {


### PR DESCRIPTION
PR upgrades snyk to version 1.1190.0 (to patch security vulnerabilities). Also moves snyk to a dev dependency to help future vulnerabilities in snyk from not being pulled in as a direct requirement.